### PR TITLE
cmake: specify 'SYSTEM' setting to disable warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ message("LLVM STATUS:
 )
 
 # Set the LLVM header and library paths
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/HelloWorld/CMakeLists.txt
+++ b/HelloWorld/CMakeLists.txt
@@ -14,7 +14,7 @@ list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 find_package(LLVM 10.0.0 REQUIRED CONFIG)
 
 # HelloWorld includes headers from LLVM - update the include paths accordingly
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
 #===============================================================================
 # 2. LLVM-TUTOR BUILD CONFIGURATION


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/include_directories.html:
> If the SYSTEM option is given, the compiler will be told the
> directories are meant as system include directories on some platforms.
> Signalling this setting might achieve effects such as the compiler
> skipping warnings, or these fixed-install system files not being
> considered in dependency calculations - see compiler docs.