### PR TITLE
Add a function argument usage analysis pass

### DIFF
--- a/include/FunctionArgumentUsagePass.h
+++ b/include/FunctionArgumentUsagePass.h
@@ -1,0 +1,118 @@
+//==============================================================================
+// FILE:
+//    FunctionArgumentUsagePass.h
+//
+// DESCRIPTION:
+//    An example of an analysis pass: reports any implicit casts around
+//    function calls.
+//    Declares the FunctionArgumentUsagePass pass and interface data types.
+//
+// License: MIT
+//==============================================================================
+
+#ifndef LLVM_TUTOR_FUNCTIONARGUMENTUSAGEPASS_H
+#define LLVM_TUTOR_FUNCTIONARGUMENTUSAGEPASS_H
+
+#include "llvm/ADT/iterator_range.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
+
+namespace llvm {
+
+class AnalysisUsage;
+class CallBase;
+class Function;
+class FunctionPass;
+class StringRef;
+class Type;
+
+} // namespace llvm
+
+struct TypeMismatchRecord {
+  llvm::StringRef callerName;
+  unsigned line;
+  bool hasLine;
+  unsigned argNo;
+  const llvm::Type *expectedType;
+  const llvm::Type *actualType;
+
+  TypeMismatchRecord(llvm::StringRef callerName, unsigned line, bool hasLine,
+                     unsigned argNo, const llvm::Type *expectedType,
+                     const llvm::Type *actualType)
+      : callerName(callerName), line(line), hasLine(hasLine), argNo(argNo),
+        expectedType(expectedType), actualType(actualType) {}
+};
+
+//------------------------------------------------------------------------------
+// New PM interface
+//------------------------------------------------------------------------------
+class FunctionArgumentUsagePass
+    : public llvm::AnalysisInfoMixin<FunctionArgumentUsagePass> {
+
+  using TypeMismatchVector = llvm::SmallVector<TypeMismatchRecord, 6>;
+
+  TypeMismatchVector typeMismatches;
+
+  void analyzeFunctionUsages(llvm::Function &F, llvm::CallBase *call);
+
+public:
+  using const_mismatch_iterator = TypeMismatchVector::const_iterator;
+
+  /// Provide the result typedef for this analysis pass.
+  using Result = llvm::iterator_range<const_mismatch_iterator>;
+
+  Result run(llvm::Function &F, llvm::FunctionAnalysisManager &);
+
+  Result runOnFunction(llvm::Function &F);
+
+  void releaseMemory();
+
+  // A special type used by analysis passes to provide an address that
+  // identifies that particular analysis pass type.
+  // or .../llvm/IR/PassManager.h:409:23: error: no member named 'Key'
+  // in 'FunctionArgumentUsagePass
+  static llvm::AnalysisKey Key;
+};
+
+class LegacyFunctionArgumentUsagePass : public llvm::FunctionPass {
+  FunctionArgumentUsagePass Impl;
+  FunctionArgumentUsagePass::Result Result;
+
+public:
+  using const_mismatch_iterator = FunctionArgumentUsagePass::const_mismatch_iterator;
+
+  static char ID;
+
+  LegacyFunctionArgumentUsagePass()
+      : llvm::FunctionPass(ID), Result(nullptr, nullptr)
+  {}
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+  }
+
+  const_mismatch_iterator begin() const {
+    return Result.begin();
+  }
+
+  const_mismatch_iterator end() const {
+    return Result.end();
+  }
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  void print(llvm::raw_ostream &O, const llvm::Module *M) const override;
+
+  void releaseMemory() override;
+};
+
+
+using TypeMismatchRange
+  = llvm::iterator_range<FunctionArgumentUsagePass::const_mismatch_iterator>;
+
+/// Helper functions
+/// Pretty-prints the result of this analysis
+void printTypeMismatches(llvm::raw_ostream &OS,
+                         const TypeMismatchRange &TypeMismatches);
+
+#endif // LLVM_TUTOR_FUNCTIONARGUMENTUSAGEPASS_H

--- a/inputs/input_for_fnargusage.c
+++ b/inputs/input_for_fnargusage.c
@@ -1,0 +1,19 @@
+int demo(int a, int *b) {
+    return a * 2 + *b;
+}
+
+int callee(char a, int b, long c) {
+    return demo(b, (long *)&a); // ptr to char -> ptr to long -> ptr to int
+}
+
+int main() {
+    callee('a', 10, 100l); // full correct call
+    int i;
+    callee(i, 10, 100L); // int instead of char
+    int *ip = &i;
+    int **ipp = &ip;
+    demo(100, ip); // full correct call
+    demo(100, ipp); // ptr instead of ptr to ptr
+    demo(100L, ip); // convert int to long - ignored by LLVM
+    return 0;
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LLVM_TUTOR_PLUGINS
     DuplicateBB
     OpcodeCounter
     MergeBB
+    FunctionArgumentUsage
     )
 
 set(StaticCallCounter_SOURCES
@@ -32,6 +33,9 @@ set(OpcodeCounter_SOURCES
   OpcodeCounter.cpp)
 set(MergeBB_SOURCES
   MergeBB.cpp)
+set(FunctionArgumentUsage_SOURCES
+  FunctionArgumentUsagePass.cpp
+  FunctionArgumentUsagePrinterPass.cpp)
 
 # CONFIGURE THE PLUGIN LIBRARIES
 # ==============================

--- a/lib/FunctionArgumentUsagePass.cpp
+++ b/lib/FunctionArgumentUsagePass.cpp
@@ -1,0 +1,204 @@
+//========================================================================
+// FILE:
+//    FunctionArgumentUsagePass.cpp
+//
+// DESCRIPTION:
+// This is an analysis pass that diagnoses type mismatches around function
+// calls. The idea is borrowed from the task "Writing your own Analysis Pass"
+// (http://www.isi.edu/~pedro/Teaching/CSCI565-Spring15/Projects/Project1-LLVM/Project1-LLVM.pdf)
+// course CSCI565 Compilers Design.
+//
+// USAGE:
+//    0. clang -O0 -g -S -emit-llvm inputs/input_for_fnargusage.c -o input_for_fnargusage.ll
+//    1. Legacy pass manager:
+//      $ opt -load <BUILD_DIR>/lib/libFunctionArgumentUsage.so \
+//        --legacy-fnargusage -analyze input_for_fnargusage.ll
+//
+// EXAMPLE OUTPUT:
+// Printing analysis 'Function Argument Usage Pass' for function 'demo':
+// Function 'main' call on line '16': argument type mismatch. Argument #1
+//   Expected 'i32*' but argument is of type 'i32**'
+// Function 'callee' call on line '6': argument type mismatch. Argument #1
+//   Expected 'i32*' but argument is of type 'i8*'
+//
+// License: MIT
+//========================================================================
+
+#include "FunctionArgumentUsagePass.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+
+#define DEBUG_TYPE "ArgUsage"
+
+STATISTIC(NumOfMismatches, "Number of type mismatches are found");
+
+using namespace llvm;
+
+#ifndef NDEBUG
+static void dumpFunctionArgs(const Function &F) {
+  dbgs() << "function '";
+  dbgs().write_escaped(F.getName());
+  dbgs() << "' takes " << F.arg_size() << " parameters:\n";
+  for (auto a = F.arg_begin(), e = F.arg_end(); a != e; ++a) {
+    if (a->hasName()) {
+      dbgs() << '\t' << a->getName();
+    } else {
+      dbgs() << "\tanonymous";
+    }
+    dbgs() << ": " << *a->getType() << '\n';
+  }
+}
+#endif
+
+#ifndef NDEBUG
+static void dumpFunctionUsedFrom(const Value *From, bool hasLine,
+                                 unsigned line) {
+  dbgs() << "and is used in the '";
+  dbgs().write_escaped(From->getName());
+  dbgs() << "' function";
+  if (hasLine) {
+    dbgs() << " (on line: " << line << ')';
+  }
+  dbgs() << ":\n";
+}
+#endif
+
+static llvm::Type* uncastOriginalType(llvm::Value *value) {
+  if (auto *inst = dyn_cast<CastInst>(value)) {
+    return uncastOriginalType(inst->getOperand(0));
+  }
+  return value->getType();
+}
+
+void FunctionArgumentUsagePass::analyzeFunctionUsages(Function &F,
+                                                      CallBase *call) {
+  bool hasLine = false;
+  unsigned line = 0;
+  if (auto &debugLoc = call->getDebugLoc()) {
+    line = call->getDebugLoc().getLine();
+    hasLine = true;
+  }
+
+  LLVM_DEBUG(dumpFunctionUsedFrom(call->getFunction(), hasLine, line));
+
+  // check on argument type mismatch
+  //   fa - a function's formal argument (an argument from
+  //        the signature of the function).
+  //   pha - a physical argument, an argument the function
+  //         is exactly executed with.
+  auto fa = F.arg_begin(), fe = F.arg_end();
+  for (auto pha = call->arg_begin(), phe = call->arg_end();
+       (fa != fe && pha != phe); ++pha, ++fa) {
+    const Type *ftypeptr = fa->getType();
+    const Type *phtypeptr = uncastOriginalType(pha->get());
+
+    LLVM_DEBUG({
+      dbgs() << "\targ #" << fa->getArgNo();
+      if (pha->get()->hasName()) {
+        dbgs() << " (" << pha->get()->getName() << ')';
+      }
+      dbgs() << ": " << *phtypeptr << '\n';
+    });
+    if (ftypeptr != phtypeptr) {
+      // type mismatch is here
+      // ... register it:
+      NumOfMismatches++;
+      typeMismatches.emplace_back(call->getFunction()->getName(), line, hasLine,
+                                  fa->getArgNo(), ftypeptr, phtypeptr);
+      LLVM_DEBUG({
+        // ... and debug:
+        dbgs() << "\ttype mismatch: expected '";
+        dbgs() << *ftypeptr << "' but argument is of type '";
+        dbgs() << *phtypeptr << "'\n";
+      });
+    }
+  }
+}
+
+FunctionArgumentUsagePass::Result
+FunctionArgumentUsagePass::run(Function &F, FunctionAnalysisManager &) {
+  return runOnFunction(F);
+}
+
+FunctionArgumentUsagePass::Result
+FunctionArgumentUsagePass::runOnFunction(Function &F) {
+  releaseMemory(); // new pass manager has to clear memory on every run
+  LLVM_DEBUG(dumpFunctionArgs(F));
+
+  for (auto use = F.use_begin(), e = F.use_end(); use != e; ++use) {
+    if (CallBase *call = dyn_cast<CallBase>(use->getUser())) {
+      analyzeFunctionUsages(F, call);
+    } else if (Operator *oper = dyn_cast<Operator>(use->getUser())) {
+      for (auto it = oper->use_begin(), ite = oper->use_end(); it != ite;
+           ++it) {
+        Value *parent = it->getUser();
+        if (CallBase *call = dyn_cast<CallBase>(parent)) {
+          analyzeFunctionUsages(F, call);
+        }
+      }
+    }
+  }
+  return Result(typeMismatches.begin(), typeMismatches.end());
+}
+
+// We can just put typeMismatches into the runOnFunction body and do not
+// invalidate it there but the goal is to demonstrate how to use
+// the releaseMemory() legacy pass method.
+void FunctionArgumentUsagePass::releaseMemory() {
+  typeMismatches.clear();
+}
+
+bool LegacyFunctionArgumentUsagePass::runOnFunction(Function &F) {
+  Result = Impl.runOnFunction(F);
+  return false;
+}
+
+void LegacyFunctionArgumentUsagePass::print(llvm::raw_ostream &O,
+                                            const Module *M) const {
+  printTypeMismatches(O, Result);
+}
+
+void LegacyFunctionArgumentUsagePass::releaseMemory() {
+  LLVM_DEBUG(dbgs() << "Release memory" << '\n');
+  Impl.releaseMemory();
+}
+
+//-----------------------------------------------------------------------------
+// For New PM Registration
+//-----------------------------------------------------------------------------
+AnalysisKey FunctionArgumentUsagePass::Key;
+
+//-----------------------------------------------------------------------------
+// Legacy PM Registration
+//-----------------------------------------------------------------------------
+
+char LegacyFunctionArgumentUsagePass::ID = 0;
+
+static RegisterPass<LegacyFunctionArgumentUsagePass> X(
+    /*PassArg=*/"legacy-fnargusage",
+    /*Name=*/"Function Argument Usage Pass",
+    /*CFGOnly=*/false,
+    /*is_analysis=*/false);
+
+//-----------------------------------------------------------------------------
+// Helper functions
+//-----------------------------------------------------------------------------
+void printTypeMismatches(llvm::raw_ostream &OS,
+                         const TypeMismatchRange &TypeMismatches) {
+  for (auto &mismatch : TypeMismatches) {
+    OS << "Function '";
+    OS.write_escaped(mismatch.callerName);
+    OS << "'";
+    if (mismatch.hasLine) {
+      OS << " call on line '" << mismatch.line << '\'';
+    }
+    OS << ": argument type mismatch. ";
+    OS << "Argument #" << mismatch.argNo << ' ';
+    OS << "Expected '" << *mismatch.expectedType << "' ";
+    OS << "but argument is of type '" << *mismatch.actualType << "'\n";
+  }
+}

--- a/lib/FunctionArgumentUsagePrinterPass.cpp
+++ b/lib/FunctionArgumentUsagePrinterPass.cpp
@@ -1,0 +1,81 @@
+//========================================================================
+// FILE:
+//    FunctionArgumentUsagePass.cpp
+//
+// DESCRIPTION:
+// This is a user of the FunctionArgumentUsagePass. It requires to trigger
+// the analysis pass using the modern pass manager.
+//
+// USAGE:
+//    1. New pass manager:
+//      $ opt -load-pass-plugin <BUILD_DIR>/lib/libFunctionArgumentUsage.so \
+//        -passes="fnargusage-user" -disable-output <bitcode-file>
+//
+// EXAMPLE OUTPUT:
+// Printing analysis 'Function Argument Usage Pass' for function 'demo':
+// Function 'main' call on line '16': argument type mismatch. Argument #1
+//   Expected 'i32*' but argument is of type 'i32**'
+// Function 'callee' call on line '6': argument type mismatch. Argument #1
+//   Expected 'i32*' but argument is of type 'i8*'
+//
+// License: MIT
+//========================================================================
+
+#include "FunctionArgumentUsagePass.h"
+
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+
+using namespace llvm;
+
+namespace {
+
+class FunctionArgumentUsagePrinterPass
+    : public PassInfoMixin<FunctionArgumentUsagePass> {
+  raw_ostream &OS;
+
+public:
+  explicit FunctionArgumentUsagePrinterPass(raw_ostream &OS) : OS(OS) {};
+
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+};
+
+PreservedAnalyses
+FunctionArgumentUsagePrinterPass::run(Function &F,
+                                      FunctionAnalysisManager &AM) {
+  OS << "Printing analysis 'Function Argument Usage Pass' for function '";
+  OS.write_escaped(F.getName());
+  OS << "'\n";
+  FunctionArgumentUsagePass::Result Result = AM.getResult<FunctionArgumentUsagePass>(F);
+  printTypeMismatches(OS, Result);
+  return PreservedAnalyses::all();
+}
+
+} // end anonymous namespace
+
+//-----------------------------------------------------------------------------
+// New PM Registration
+//-----------------------------------------------------------------------------
+PassPluginLibraryInfo getFunctionArgumentUsagePluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "fnargusage", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerAnalysisRegistrationCallback(
+                [](FunctionAnalysisManager &FAM) {
+                  FAM.registerPass([&] { return FunctionArgumentUsagePass(); });
+                });
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, FunctionPassManager &FPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == "fnargusage-user") {
+                    FPM.addPass(FunctionArgumentUsagePrinterPass(errs()));
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getFunctionArgumentUsagePluginInfo();
+}


### PR DESCRIPTION
The idea is borrowed from the task 'Writing your own Analysis Pass',
course 'CSCI565 Compilers Design' (see http://www.isi.edu/~pedro/Teaching/CSCI565-Spring15/Projects/Project1-LLVM/Project1-LLVM.pdf).

The pass analyses function usages in an LLVM IR module and checks that
the types of the parameters agree in type with those of the call
instruction.

The format of printing the errors the pass founds is as follows:
Function 'X' call on line 'Y': argument type mismatch. Expected 'int' but argument is of type 'char'.
(information about the line can be printed only if the debug locations
are fount in the bitcode).

The pass can be run with the new pass manager:

$ opt -load-pass-plugin lib/libFunctionArgumentUsage.so -passes="fnargusage-user" -disable-output input_for_fnargusage.ll

as well as with the legacy one:

$ opt -load lib/libFunctionArgumentUsage.so --legacy-fnargusage -analyze -stats input_for_fnargusage.ll

The pass is designed in a way that let to the pass display debug
information about the analysis process. To enable debug output, the pass
should be run with the '--debug-only=ArgUsage' parameter:

$ opt -load lib/libFunctionArgumentUsage.so -legacy-fnargusage -debug-pass=Structure --debug-only=ArgUsage -analyze input_for_fnargusage.ll

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>