### PR TITLE
Add necessary libraries to `static` executable

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,11 @@ add_executable(static
 )
 
 target_link_libraries(static
-  LLVMPasses)
+  LLVMCore
+  LLVMPasses
+  LLVMIRReader
+  LLVMSupport
+  )
 
 target_include_directories(
   static


### PR DESCRIPTION
If you link against a dylib build (e.g. when building in debug mode)
you'll need these.