### PR TITLE
Added check for /usr/lib64 for fix issue in Fedora 33

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ endif()
 
 set(LT_LLVM_CMAKE_FILE "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/LLVMConfig.cmake")
 if(NOT EXISTS "${LT_LLVM_CMAKE_FILE}")
+set(LT_LLVM_CMAKE_FILE "${LT_LLVM_INSTALL_DIR}/lib64/cmake/llvm/LLVMConfig.cmake")
+endif()
+if(NOT EXISTS "${LT_LLVM_CMAKE_FILE}")
 message(FATAL_ERROR
     " LT_LLVM_CMAKE_FILE (${LT_LLVM_CMAKE_FILE}) is invalid.")
 endif()


### PR DESCRIPTION
Effects:
- If your initial call to cmake worked before it should still work
- If you had the same issue I had with the existence of /lib64 this fixes it
- CMakeLists.txt is a bit more cluttered though

I think this will lower a significant barrier to folks who are going to install the llvm-devel package but not necessarily build llvm-project from source.