### PR TITLE
Add "-c" arg when expecting llvm bitcode output

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ export LLVM_DIR=<installation/dir/of/llvm/12>
 # Textual form
 $LLVM_DIR/bin/clang -O1 -emit-llvm input.c -S -o out.ll
 # Binary/bit-code form
-$LLVM_DIR/bin/clang -O1 -emit-llvm input.c -o out.bc
+$LLVM_DIR/bin/clang -O1 -emit-llvm input.c -c -o out.bc
 ```
 It doesn't matter whether you choose the binary, `*.bc` (default), or textual
 (`.ll`, requires the `-S` flag) form, but obviously the latter is more

--- a/tools/StaticMain.cpp
+++ b/tools/StaticMain.cpp
@@ -9,7 +9,7 @@
 //
 // USAGE:
 //    # First, generate an LLVM file:
-//      clang -emit-llvm <input-file> -o <output-llvm-file>
+//      clang -emit-llvm <input-file> -c -o <output-llvm-file>
 //    # Now you can run this tool as follows:
 //      <BUILD/DIR>/bin/static <output-llvm-file>
 //


### PR DESCRIPTION
If there isn't "-c" argument, clang will generate an error "clang-12: error: -emit-llvm cannot be used when linking".