### PR TITLE
add enable-new-pm=0 to enable legacy pass manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ export LLVM_DIR=<installation/dir/of/llvm/13>
 # Generate an LLVM file to analyze
 $LLVM_DIR/bin/clang -emit-llvm -c <source_dir>/inputs/input_for_cc.c -o input_for_cc.bc
 # Run the pass through opt - Legacy PM
-$LLVM_DIR/bin/opt -load <build_dir>/lib/libOpcodeCounter.so -legacy-opcode-counter -analyze input_for_cc.bc
+$LLVM_DIR/bin/opt -enable-new-pm=0 -load <build_dir>/lib/libOpcodeCounter.so -legacy-opcode-counter -analyze input_for_cc.bc
 # Run the pass through opt - New PM
 $LLVM_DIR/bin/opt -load-pass-plugin <build_dir>/lib/libOpcodeCounter.so --passes="print<opcode-counter>" -disable-output input_for_cc.bc
 ```
@@ -375,7 +375,7 @@ export LLVM_DIR=<installation/dir/of/llvm/13>
 # Generate an LLVM file to analyze
 $LLVM_DIR/bin/clang -O0 -emit-llvm -c <source_dir>/inputs/input_for_hello.c -o input_for_hello.bc
 # Run the pass through opt - Legacy PM
-$LLVM_DIR/bin/opt -load <build_dir>/lib/libInjectFuncCall.so -legacy-inject-func-call input_for_hello.bc -o instrumented.bin
+$LLVM_DIR/bin/opt -enable-new-pm=0 -load <build_dir>/lib/libInjectFuncCall.so -legacy-inject-func-call input_for_hello.bc -o instrumented.bin
 # Run the pass through opt - New PM
 $LLVM_DIR/bin/opt -load-pass-plugin <build_dir>/lib/libInjectFuncCall.so --passes="inject-func-call" input_for_hello.bc -o instrumented.bin
 ```
@@ -448,7 +448,7 @@ export LLVM_DIR=<installation/dir/of/llvm/13>
 # Generate an LLVM file to analyze
 $LLVM_DIR/bin/clang -emit-llvm -c <source_dir>/inputs/input_for_cc.c -o input_for_cc.bc
 # Run the pass through opt - Legacy PM
-$LLVM_DIR/bin/opt -load <build_dir>/lib/libStaticCallCounter.so -legacy-static-cc -analyze input_for_cc.bc
+$LLVM_DIR/bin/opt -enable-new-pm=0 -load <build_dir>/lib/libStaticCallCounter.so -legacy-static-cc -analyze input_for_cc.bc
 ```
 You should see the following output:
 
@@ -623,7 +623,7 @@ export LLVM_DIR=<installation/dir/of/llvm/13>
 # Generate an LLVM file to analyze
 $LLVM_DIR/bin/clang -emit-llvm -S -O1 <source_dir>/inputs/input_for_riv.c -o input_for_riv.ll
 # Run the pass through opt - Legacy PM
-$LLVM_DIR/bin/opt -load <build_dir>/lib/libRIV.so -legacy-riv -analyze input_for_riv.ll
+$LLVM_DIR/bin/opt -enable-new-pm=0 -load <build_dir>/lib/libRIV.so -legacy-riv -analyze input_for_riv.ll
 ```
 You will see the following output:
 


### PR DESCRIPTION
There were a few places where I wanted to run the legacy pass manager as mentioned in the `README.md` file, but they were failing. I found that I needed to add `enable-new-pm=0` in order to use the legacy pass manager. Below are some of my findings and my reasoning for adding this flag in certain places in the README.

```
$LLVM_DIR/bin/clang -emit-llvm -c ${TUTOR_SRC_DIR}/inputs/input_for_cc.c -o input_for_cc.bc
# Run the pass through opt - Legacy PM
# Does not work
$LLVM_DIR/bin/opt -load ${TUTOR_BUILD_DIR}/lib/libOpcodeCounter.so -legacy-opcode-counter -analyze input_for_cc.bc
Cannot specify -analyze under new pass manager, either specify '-enable-new-pm=0', or use the corresponding new pass manager pass, e.g. '-passes=print<scalar-evolution>'. For a full list of passes, see the '--print-passes' flag.

# Works
$LLVM_DIR/bin/opt -enable-new-pm=0 -load ${TUTOR_BUILD_DIR}/lib/libOpcodeCounter.so -legacy-opcode-counter -analyze input_for_cc.bc
Printing analysis 'Legacy OpcodeCounter Pass' for function 'foo':
=================================================
LLVM-TUTOR: OpcodeCounter results
=================================================
OPCODE               #TIMES USED
-------------------------------------------------
ret                  1         
-------------------------------------------------

Printing analysis 'Legacy OpcodeCounter Pass' for function 'bar':
=================================================
LLVM-TUTOR: OpcodeCounter results
=================================================
OPCODE               #TIMES USED
-------------------------------------------------
ret                  1         
call                 1         
-------------------------------------------------

Printing analysis 'Legacy OpcodeCounter Pass' for function 'fez':
=================================================
LLVM-TUTOR: OpcodeCounter results
=================================================
OPCODE               #TIMES USED
-------------------------------------------------
ret                  1         
call                 1         
-------------------------------------------------

Printing analysis 'Legacy OpcodeCounter Pass' for function 'main':
=================================================
LLVM-TUTOR: OpcodeCounter results
=================================================
OPCODE               #TIMES USED
-------------------------------------------------
load                 2         
br                   4         
icmp                 1         
add                  1         
ret                  1         
alloca               2         
store                4         
call                 4         
-------------------------------------------------
```

```
# Generate an LLVM file to analyze
$LLVM_DIR/bin/clang -O0 -emit-llvm -S ${TUTOR_SRC_DIR}/inputs/input_for_hello.c -o input_for_hello.bc
# Run the pass through opt - Legacy PM
# Does not work
$LLVM_DIR/bin/opt -load ${TUTOR_BUILD_DIR}/lib/libInjectFuncCall.so -legacy-inject-func-call input_for_hello.bc -o instrumented.bin
/usr/lib/llvm-13/bin/opt: unknown pass name 'legacy-inject-func-call'

# Works
$ $LLVM_DIR/bin/opt -enable-new-pm=0 -load ${TUTOR_BUILD_DIR}/lib/libInjectFuncCall.so -legacy-inject-func-call input_for_hello.bc -S -o instrumented.bin
$ cat instrumented.bin
; ModuleID = 'input_for_hello.bc'
source_filename = "/home/93u/Sandbox/llvm/andrzej-llvm-tutor/llvm-tutor/inputs/input_for_hello.c"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu"

@PrintfFormatStr = global [68 x i8] c"(llvm-tutor) Hello from: %s\0A(llvm-tutor)   number of arguments: %d\0A\00"
@0 = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@1 = private unnamed_addr constant [4 x i8] c"bar\00", align 1
@2 = private unnamed_addr constant [4 x i8] c"fez\00", align 1
@3 = private unnamed_addr constant [5 x i8] c"main\00", align 1

; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @foo(i32 %0) #0 {
  %2 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([68 x i8], [68 x i8]* @PrintfFormatStr, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0), i32 1)
  %3 = alloca i32, align 4
  store i32 %0, i32* %3, align 4
  %4 = load i32, i32* %3, align 4
  %5 = mul nsw i32 %4, 2
  ret i32 %5
}

; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @bar(i32 %0, i32 %1) #0 {
  %3 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([68 x i8], [68 x i8]* @PrintfFormatStr, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @1, i32 0, i32 0), i32 2)
  %4 = alloca i32, align 4
  %5 = alloca i32, align 4
  store i32 %0, i32* %4, align 4
  store i32 %1, i32* %5, align 4
  %6 = load i32, i32* %4, align 4
  %7 = load i32, i32* %5, align 4
  %8 = call i32 @foo(i32 %7)
  %9 = mul nsw i32 %8, 2
  %10 = add nsw i32 %6, %9
  ret i32 %10
}

; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @fez(i32 %0, i32 %1, i32 %2) #0 {
  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([68 x i8], [68 x i8]* @PrintfFormatStr, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @2, i32 0, i32 0), i32 3)
  %5 = alloca i32, align 4
  %6 = alloca i32, align 4
  %7 = alloca i32, align 4
  store i32 %0, i32* %5, align 4
  store i32 %1, i32* %6, align 4
  store i32 %2, i32* %7, align 4
  %8 = load i32, i32* %5, align 4
  %9 = load i32, i32* %5, align 4
  %10 = load i32, i32* %6, align 4
  %11 = call i32 @bar(i32 %9, i32 %10)
  %12 = mul nsw i32 %11, 2
  %13 = add nsw i32 %8, %12
  %14 = load i32, i32* %7, align 4
  %15 = mul nsw i32 %14, 3
  %16 = add nsw i32 %13, %15
  ret i32 %16
}

; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @main(i32 %0, i8** %1) #0 {
  %3 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([68 x i8], [68 x i8]* @PrintfFormatStr, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i32 2)
  %4 = alloca i32, align 4
  %5 = alloca i32, align 4
  %6 = alloca i8**, align 8
  %7 = alloca i32, align 4
  %8 = alloca i32, align 4
  store i32 0, i32* %4, align 4
  store i32 %0, i32* %5, align 4
  store i8** %1, i8*** %6, align 8
  store i32 123, i32* %7, align 4
  store i32 0, i32* %8, align 4
  %9 = load i32, i32* %7, align 4
  %10 = call i32 @foo(i32 %9)
  %11 = load i32, i32* %8, align 4
  %12 = add nsw i32 %11, %10
  store i32 %12, i32* %8, align 4
  %13 = load i32, i32* %7, align 4
  %14 = load i32, i32* %8, align 4
  %15 = call i32 @bar(i32 %13, i32 %14)
  %16 = load i32, i32* %8, align 4
  %17 = add nsw i32 %16, %15
  store i32 %17, i32* %8, align 4
  %18 = load i32, i32* %7, align 4
  %19 = load i32, i32* %8, align 4
  %20 = call i32 @fez(i32 %18, i32 %19, i32 123)
  %21 = load i32, i32* %8, align 4
  %22 = add nsw i32 %21, %20
  store i32 %22, i32* %8, align 4
  %23 = load i32, i32* %8, align 4
  ret i32 %23
}

; Function Attrs: nounwind
declare i32 @printf(i8* nocapture readonly, ...) #1

attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
attributes #1 = { nounwind }

!llvm.module.flags = !{!0, !1, !2}
!llvm.ident = !{!3}

!0 = !{i32 1, !"wchar_size", i32 4}
!1 = !{i32 7, !"uwtable", i32 1}
!2 = !{i32 7, !"frame-pointer", i32 2}
!3 = !{!"Ubuntu clang version 13.0.1-++20220120110924+75e33f71c2da-1~exp1~20220120231001.58"}
```

```
$LLVM_DIR/bin/clang -emit-llvm -c ${TUTOR_SRC_DIR}/inputs/input_for_cc.c -o input_for_cc.bc
# Run the pass through opt - Legacy PM
# Doesn't work
$LLVM_DIR/bin/opt -load ${TUTOR_BUILD_DIR}/lib/libStaticCallCounter.so -legacy-static-cc -analyze input_for_cc.bc
Cannot specify -analyze under new pass manager, either specify '-enable-new-pm=0', or use the corresponding new pass manager pass, e.g. '-passes=print<scalar-evolution>'. For a full list of passes, see the '--print-passes' flag.


# works
$LLVM_DIR/bin/opt -enable-new-pm=0 -load ${TUTOR_BUILD_DIR}/lib/libStaticCallCounter.so -legacy-static-cc -analyze input_for_cc.bc
Printing analysis 'LegacyStaticCallCounter':
=================================================
LLVM-TUTOR: static analysis results
=================================================
NAME                 #N DIRECT CALLS
-------------------------------------------------
foo                  3         
bar                  2         
fez                  1         
-------------------------------------------------
```

```
$LLVM_DIR/bin/clang -emit-llvm -S -O1 ${TUTOR_SRC_DIR}/inputs/input_for_riv.c -o input_for_riv.ll
# Run the pass through opt - Legacy PM
# Doesn't work
$LLVM_DIR/bin/opt -load ${TUTOR_BUILD_DIR}/lib/libRIV.so -legacy-riv -analyze input_for_riv.ll
Cannot specify -analyze under new pass manager, either specify '-enable-new-pm=0', or use the corresponding new pass manager pass, e.g. '-passes=print<scalar-evolution>'. For a full list of passes, see the '--print-passes' flag.


# works
$LLVM_DIR/bin/opt -enable-new-pm=0 -load ${TUTOR_BUILD_DIR}/lib/libRIV.so -legacy-riv -analyze input_for_riv.ll
=================================================
LLVM-TUTOR: RIV analysis results
=================================================
BB id      Reachable Ineger Values       
-------------------------------------------------
BB %3                                         
             i32 %0                        
             i32 %1                        
             i32 %2                        
BB %6                                         
               %4 = add nsw i32 %0, 123    
               %5 = icmp sgt i32 %0, 0     
             i32 %0                        
             i32 %1                        
             i32 %2                        
BB %17                                        
               %4 = add nsw i32 %0, 123    
               %5 = icmp sgt i32 %0, 0     
             i32 %0                        
             i32 %1                        
             i32 %2                        
BB %10                                        
               %7 = mul nsw i32 %1, %0     
               %8 = sdiv i32 %1, %2        
               %9 = icmp eq i32 %7, %8     
               %4 = add nsw i32 %0, 123    
               %5 = icmp sgt i32 %0, 0     
             i32 %0                        
             i32 %1                        
             i32 %2                        
BB %14                                        
               %7 = mul nsw i32 %1, %0     
               %8 = sdiv i32 %1, %2        
               %9 = icmp eq i32 %7, %8     
               %4 = add nsw i32 %0, 123    
               %5 = icmp sgt i32 %0, 0     
             i32 %0                        
             i32 %1                        
             i32 %2                   
```