### PR TITLE
[CMake] Display header files in Xcode

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,6 +39,22 @@ set(OpcodeCounter_SOURCES
 set(MergeBB_SOURCES
   MergeBB.cpp)
 
+# Display header files in Xcode
+foreach(plugin ${LLVM_TUTOR_PLUGINS})
+  if(XCODE)
+    if((plugin STREQUAL MBAAdd) OR (plugin STREQUAL MBASub))
+      set(extra_headers ../include/Ratio.h)
+    else()
+      set(extra_headers)
+    endif()
+    file(GLOB ${plugin}_HEADERS ../include/${plugin}.h ${extra_headers})
+    set_source_files_properties(${${plugin}_HEADERS} PROPERTIES HEADER_FILE_ONLY true)
+    source_group("Header Files" FILES ${${plugin}_HEADERS})
+  else()
+    set(${plugin}_HEADERS)
+  endif()
+endforeach()
+
 # CONFIGURE THE PLUGIN LIBRARIES
 # ==============================
 foreach( plugin ${LLVM_TUTOR_PLUGINS} )
@@ -47,6 +63,7 @@ foreach( plugin ${LLVM_TUTOR_PLUGINS} )
       ${plugin}
       SHARED
       ${${plugin}_SOURCES}
+      ${${plugin}_HEADERS}
       )
 
     # Configure include directories for 'plugin'

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,7 +3,16 @@ set(static_SOURCES
   "${CMAKE_CURRENT_SOURCE_DIR}/../lib/StaticCallCounter.cpp"
 )
 
-add_executable(static ${static_SOURCES})
+# Display header files in Xcode
+if(XCODE)
+  file(GLOB static_HEADERS ../include/StaticCallCounter.h)
+  set_source_files_properties(${static_HEADERS} PROPERTIES HEADER_FILE_ONLY true)
+  source_group("Header Files" FILES ${static_HEADERS})
+else()
+  set(static_HEADERS)
+endif()
+
+add_executable(static ${static_SOURCES} ${static_HEADERS})
 
 target_include_directories(
   static


### PR DESCRIPTION
Normally Xcode projects generated by CMake contain only the source files for each target. This change adds the header files too, making it easier to use Xcode.