### PR TITLE
Update CI fedora version to install llvm-16

### DIFF
--- a/Dockerfile_fedora
+++ b/Dockerfile_fedora
@@ -10,7 +10,7 @@
 # ```
 # =============================================================================
 
-FROM fedora:37
+FROM fedora:38
 
 ENV LLVM_DIR /usr/
 ENV TUTOR_DIR /llvm-tutor


### PR DESCRIPTION
Fedora and Arch failed to install llvm-16 https://github.com/banach-space/llvm-tutor/actions/runs/5228927774/jobs/9478775929.

It seems like arch linux package doesn't have llvm-16. https://archlinux.org/packages/?sort=&q=llvm&maintainer=&flagged=

But updating the version for Fedora solves the fedora problem.