### PR TITLE
Fixed lit install on ARCH Linux - venv instead of system install

### DIFF
--- a/Dockerfile_archlinux
+++ b/Dockerfile_archlinux
@@ -14,6 +14,7 @@ FROM archlinux
 
 ENV LLVM_DIR /usr/
 ENV TUTOR_DIR /llvm-tutor
+ENV VENV_DIR /venv
 
 # 1. INSTALL DEPENDENCIES
 RUN pacman -Syu --noconfirm \
@@ -26,7 +27,8 @@ RUN pacman -Syu --noconfirm \
     python-pip
 
 # 2. INSTALL LIT
-RUN pip3 install lit
+RUN python3 -m venv $VENV_DIR
+RUN $VENV_DIR/bin/pip3 install lit
 
 # 3. CLONE LLVM-TUTOR
 RUN git clone https://github.com/banach-space/llvm-tutor $TUTOR_DIR
@@ -44,4 +46,4 @@ RUN mkdir -p $TUTOR_DIR/build \
     && cd $TUTOR_DIR/build \
     && cmake -G Ninja -DLT_LLVM_INSTALL_DIR=$LLVM_DIR ../ \
     && ninja \
-    && lit test/
+    && $VENV_DIR/bin/lit test/


### PR DESCRIPTION
Hello, Andrzej Warzyński

I have resolved the `lit` installation issue.

The arch uses LLVM-15, unfortunatly.
I can't resolve all assessable issue right now.

Could you review & accept my pr, pls?

Best regards, Proydakov Evgeny.