### PR TITLE
Compiles with llvm 17. Solves #98.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,14 @@ endif()
 # `find_package(llvm)`. So there's no need to add it here.
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 16 REQUIRED CONFIG)
+# The way LLVMConfigVersion.cmake is set up, it will only match MAJOR.MINOR
+# exactly, even if we do not specify "REQUIRED" in the statement below.
+# So we accept any version and do the proper ranged check below.
+find_package(LLVM CONFIG)
 
-# Another sanity check
-if(NOT "16" VERSION_EQUAL "${LLVM_VERSION_MAJOR}")
-  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM 16")
+# We defer the version checking to this statement
+if("${LLVM_VERSION_MAJOR}" VERSION_LESS 16)
+  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM 16 or above")
 endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/HelloWorld/CMakeLists.txt
+++ b/HelloWorld/CMakeLists.txt
@@ -12,7 +12,10 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
 # FIXME: This is a warkaround for #25. Remove once resolved and use
-find_package(LLVM 16 REQUIRED CONFIG)
+find_package(LLVM CONFIG)
+if("${LLVM_VERSION_MAJOR}" VERSION_LESS 16)
+  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM 16 or above")
+endif()
 
 # HelloWorld includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/lib/RIV.cpp
+++ b/lib/RIV.cpp
@@ -26,7 +26,7 @@
 //    -------------------------------------------------------------------------
 //
 // REFERENCES:
-//    Based on examples from: 
+//    Based on examples from:
 //    "Building, Testing and Debugging a Simple out-of-tree LLVM Pass", Serge
 //    Guelton and Adrien Guinet, LLVM Dev Meeting 2015
 //
@@ -75,7 +75,11 @@ RIV::Result RIV::buildRIV(Function &F, NodeTy CFGRoot) {
   // variables and input arguments.
   auto &EntryBBValues = ResultMap[&F.getEntryBlock()];
 
+#if LLVM_VERSION_MAJOR >= 17
+  for (auto &Global : F.getParent()->globals())
+#else
   for (auto &Global : F.getParent()->getGlobalList())
+#endif
     if (Global.getValueType()->isIntegerTy())
       EntryBBValues.insert(&Global);
 
@@ -120,9 +124,8 @@ RIV::Result RIV::run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM) {
   return Res;
 }
 
-PreservedAnalyses
-RIVPrinter::run(Function &Func,
-                              FunctionAnalysisManager &FAM) {
+PreservedAnalyses RIVPrinter::run(Function &Func,
+                                  FunctionAnalysisManager &FAM) {
 
   auto RIVMap = FAM.getResult<RIV>(Func);
 


### PR DESCRIPTION
There is a single change in ABI that breaks compiling with clang-17: LLVMModule::getGlobalList() to LLVMModule::globals(). That was wrapped with an `#if` 

A second change is to match any provided LLVM version in `find_package()` and use a second check to match major versions from 16 to 17. The reason for this is that even though we can provide a version range in `find_package()`, the LLVMConfigVersion.cmake installed with the llvm distribution will only match *exactly* the MAJOR.MINOR version. 