### PR TITLE
Remove include of legacy include file

### DIFF
--- a/lib/OpcodeCounter.cpp
+++ b/lib/OpcodeCounter.cpp
@@ -28,7 +28,6 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
Upstream LLVM commit d623b2f95fd559901f008a0588dddd0949a8db01 removed PassManagerBuilder and its header file.