### PR TITLE
delete legacy PM usage

### DIFF
--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -51,6 +51,19 @@ struct HelloWorld : PassInfoMixin<HelloWorld> {
   static bool isRequired() { return true; }
 };
 
+// Legacy PM implementation
+struct LegacyHelloWorld : public FunctionPass {
+  static char ID;
+  LegacyHelloWorld() : FunctionPass(ID) {}
+  // Main entry point - the name conveys what unit of IR this is to be run on.
+  bool runOnFunction(Function &F) override {
+    visitor(F);
+    // Doesn't modify the input unit of IR, hence 'false'
+    return false;
+  }
+};
+} // namespace
+
 //-----------------------------------------------------------------------------
 // New PM Registration
 //-----------------------------------------------------------------------------
@@ -76,3 +89,19 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 llvmGetPassPluginInfo() {
   return getHelloWorldPluginInfo();
 }
+
+//-----------------------------------------------------------------------------
+// Legacy PM Registration
+//-----------------------------------------------------------------------------
+// The address of this variable is used to uniquely identify the pass. The
+// actual value doesn't matter.
+char LegacyHelloWorld::ID = 0;
+
+// This is the core interface for pass plugins. It guarantees that 'opt' will
+// recognize LegacyHelloWorld when added to the pass pipeline on the command
+// line, i.e.  via '--legacy-hello-world'
+static RegisterPass<LegacyHelloWorld>
+    X("legacy-hello-world", "Hello World Pass",
+      true, // This pass doesn't modify the CFG => true
+      false // This pass is not a pure analysis pass => false
+    );

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -9,10 +9,7 @@
 //    there's no 'print' method here (every analysis pass should implement it).
 //
 // USAGE:
-//    1. Legacy PM
-//      opt --bugpoint-enable-legacy-pm -load libHelloWorld.dylib -legacy-hello-world -disable-output `\`
-//        <input-llvm-file>
-//    2. New PM
+//    New PM
 //      opt -load-pass-plugin=libHelloWorld.dylib -passes="hello-world" `\`
 //        -disable-output <input-llvm-file>
 //

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -51,19 +51,6 @@ struct HelloWorld : PassInfoMixin<HelloWorld> {
   static bool isRequired() { return true; }
 };
 
-// Legacy PM implementation
-struct LegacyHelloWorld : public FunctionPass {
-  static char ID;
-  LegacyHelloWorld() : FunctionPass(ID) {}
-  // Main entry point - the name conveys what unit of IR this is to be run on.
-  bool runOnFunction(Function &F) override {
-    visitor(F);
-    // Doesn't modify the input unit of IR, hence 'false'
-    return false;
-  }
-};
-} // namespace
-
 //-----------------------------------------------------------------------------
 // New PM Registration
 //-----------------------------------------------------------------------------
@@ -89,19 +76,3 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 llvmGetPassPluginInfo() {
   return getHelloWorldPluginInfo();
 }
-
-//-----------------------------------------------------------------------------
-// Legacy PM Registration
-//-----------------------------------------------------------------------------
-// The address of this variable is used to uniquely identify the pass. The
-// actual value doesn't matter.
-char LegacyHelloWorld::ID = 0;
-
-// This is the core interface for pass plugins. It guarantees that 'opt' will
-// recognize LegacyHelloWorld when added to the pass pipeline on the command
-// line, i.e.  via '--legacy-hello-world'
-static RegisterPass<LegacyHelloWorld>
-    X("legacy-hello-world", "Hello World Pass",
-      true, // This pass doesn't modify the CFG => true
-      false // This pass is not a pure analysis pass => false
-    );

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -10,7 +10,7 @@
 //
 // USAGE:
 //    1. Legacy PM
-//      opt -enable-new-pm=0 -load libHelloWorld.dylib -legacy-hello-world -disable-output `\`
+//      opt --bugpoint-enable-legacy-pm -load libHelloWorld.dylib -legacy-hello-world -disable-output `\`
 //        <input-llvm-file>
 //    2. New PM
 //      opt -load-pass-plugin=libHelloWorld.dylib -passes="hello-world" `\`


### PR DESCRIPTION
when enable legacy PassManager with the following command: opt-17 -enable-new-pm=0 -load ./libHelloWorld.so -legacy-hello-world -disable-output input_for_hello.ll there is an error: opt-17: Unknown command line argument '-enable-new-pm=0'. Try: 'opt-17 --help'，
![image](https://github.com/banach-space/llvm-tutor/assets/71133371/e8378139-8f97-4c31-b094-a5c7dcef8b79)

using --bugpoint-enable-legacy-pm can solve this.
![image](https://github.com/banach-space/llvm-tutor/assets/71133371/4b1b600a-6855-4fb2-93b0-5709b37aac40)
