### PR TITLE
delete legacy PM example and usage

### DIFF
--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -9,10 +9,7 @@
 //    there's no 'print' method here (every analysis pass should implement it).
 //
 // USAGE:
-//    1. Legacy PM
-//      opt -enable-new-pm=0 -load libHelloWorld.dylib -legacy-hello-world -disable-output `\`
-//        <input-llvm-file>
-//    2. New PM
+//    New PM
 //      opt -load-pass-plugin=libHelloWorld.dylib -passes="hello-world" `\`
 //        -disable-output <input-llvm-file>
 //
@@ -53,18 +50,6 @@ struct HelloWorld : PassInfoMixin<HelloWorld> {
   // all functions with optnone.
   static bool isRequired() { return true; }
 };
-
-// Legacy PM implementation
-struct LegacyHelloWorld : public FunctionPass {
-  static char ID;
-  LegacyHelloWorld() : FunctionPass(ID) {}
-  // Main entry point - the name conveys what unit of IR this is to be run on.
-  bool runOnFunction(Function &F) override {
-    visitor(F);
-    // Doesn't modify the input unit of IR, hence 'false'
-    return false;
-  }
-};
 } // namespace
 
 //-----------------------------------------------------------------------------
@@ -92,19 +77,3 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 llvmGetPassPluginInfo() {
   return getHelloWorldPluginInfo();
 }
-
-//-----------------------------------------------------------------------------
-// Legacy PM Registration
-//-----------------------------------------------------------------------------
-// The address of this variable is used to uniquely identify the pass. The
-// actual value doesn't matter.
-char LegacyHelloWorld::ID = 0;
-
-// This is the core interface for pass plugins. It guarantees that 'opt' will
-// recognize LegacyHelloWorld when added to the pass pipeline on the command
-// line, i.e.  via '--legacy-hello-world'
-static RegisterPass<LegacyHelloWorld>
-    X("legacy-hello-world", "Hello World Pass",
-      true, // This pass doesn't modify the CFG => true
-      false // This pass is not a pure analysis pass => false
-    );


### PR DESCRIPTION
I previously submitted a pull request, and after discussing with you, we reached an agreement to remove the legacy usage and example. However, multiple commits from me resulted in a confusing submission. I have made the necessary changes and resubmitted the pull request.