### PR TITLE
Migrated to use Module::createRNG and removed anonymous namespace where static functions were appropriate

### DIFF
--- a/include/DuplicateBB.h
+++ b/include/DuplicateBB.h
@@ -17,6 +17,11 @@
 #include "llvm/Pass.h"
 
 #include <map>
+#include <memory>
+
+namespace llvm {
+class RandomNumberGenerator;
+} // namespace llvm
 
 //------------------------------------------------------------------------------
 // New PM interface
@@ -51,6 +56,8 @@ struct DuplicateBB : public llvm::PassInfoMixin<DuplicateBB> {
   // decorated with the optnone LLVM attribute. Note that clang -O0 decorates
   // all functions with optnone.
   static bool isRequired() { return true; }
+
+  std::unique_ptr<llvm::RandomNumberGenerator> pRNG;
 };
 
 #endif

--- a/lib/ConvertFCmpEq.cpp
+++ b/lib/ConvertFCmpEq.cpp
@@ -47,9 +47,7 @@
 using namespace llvm;
 
 // Unnamed namespace for private functions
-namespace {
-
-FCmpInst *convertFCmpEqInstruction(FCmpInst *FCmp) noexcept {
+static FCmpInst *convertFCmpEqInstruction(FCmpInst *FCmp) noexcept {
   assert(FCmp && "The given fcmp instruction is null");
 
   if (!FCmp->isEquality()) {
@@ -114,8 +112,6 @@ FCmpInst *convertFCmpEqInstruction(FCmpInst *FCmp) noexcept {
   FCmp->setOperand(1, EpsilonValue);
   return FCmp;
 }
-
-} // namespace
 
 static constexpr char PassArg[] = "convert-fcmp-eq";
 static constexpr char PassName[] =

--- a/lib/FindFCmpEq.cpp
+++ b/lib/FindFCmpEq.cpp
@@ -45,9 +45,6 @@
 
 using namespace llvm;
 
-// Unnamed namespace for internal functions
-namespace {
-
 static void
 printFCmpEqInstructions(raw_ostream &OS, Function &Func,
                         const FindFCmpEq::Result &FCmpEqInsts) noexcept {
@@ -67,8 +64,6 @@ printFCmpEqInstructions(raw_ostream &OS, Function &Func,
     OS << '\n';
   }
 }
-
-} // namespace
 
 static constexpr char PassArg[] = "find-fcmp-eq";
 static constexpr char PassName[] =


### PR DESCRIPTION
Changed DuplicateBB to use Module::createRNG.

As LLVM style guide states:
> make anonymous namespaces as small as possible, and only use them for class declarations. 

but in fcmpEq plugins those were used for functions -> changed to use static.