### PR TITLE
🩹 Fix: Fix lib/RIV.cpp Spelling Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ You will see the following output:
 =================================================
 LLVM-TUTOR: RIV analysis results
 =================================================
-BB id      Reachable Ineger Values
+BB id      Reachable Integer Values
 -------------------------------------------------
 BB %entry
              i32 %a

--- a/lib/RIV.cpp
+++ b/lib/RIV.cpp
@@ -170,7 +170,7 @@ static void printRIVResult(raw_ostream &OutS, const RIV::Result &RIVMap) {
   OutS << "=================================================\n";
 
   const char *Str1 = "BB id";
-  const char *Str2 = "Reachable Ineger Values";
+  const char *Str2 = "Reachable Integer Values";
   OutS << format("%-10s %-30s\n", Str1, Str2);
   OutS << "-------------------------------------------------\n";
 


### PR DESCRIPTION
This PR fixes a spelling typo of the word "Integer" in `lib/RIV.cpp` and `README.md`.

### lib/RIV.cpp Change
```diff
-  const char *Str2 = "Reachable Ineger Values";
+  const char *Str2 = "Reachable Integer Values";
```

### README.md Change
```diff
 =================================================
 LLVM-TUTOR: RIV analysis results
 =================================================
-  BB id      Reachable Ineger Values
+  BB id      Reachable Integer Values
 -------------------------------------------------
```

Fixes #122 